### PR TITLE
fixed import stream identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ func main() {
     rs := bytes.NewReader(pdfBytes)
 
     // Import in-memory PDF stream with gofpdi free pdf document importer                                                                             
-    tpl1 := gofpdi.ImportPageFromStream(pdf, rs, 1, "/TrimBox")
+    tpl1 := gofpdi.ImportPageFromStream(pdf, &rs, 1, "/TrimBox")
 
     pdf.AddPage()
 

--- a/importer.go
+++ b/importer.go
@@ -84,11 +84,11 @@ func (this *Importer) SetSourceFile(f string) {
 	}
 }
 
-func (this *Importer) SetSourceStream(rs io.ReadSeeker) {
-	this.sourceFile = fmt.Sprintf("%v", &rs)
+func (this *Importer) SetSourceStream(rs *io.ReadSeeker) {
+	this.sourceFile = fmt.Sprintf("%v", rs)
 
 	if _, ok := this.readers[this.sourceFile]; !ok {
-		reader, err := NewPdfReaderFromStream(rs)
+		reader, err := NewPdfReaderFromStream(*rs)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
I just noticed a mistake in my last commit: Though io.ReadSeeker is an interface, it still needs to be passed as a pointer argument. Otherwise the identifier might still change on multiple calls. 
I'm very sorry for the inconvenience!