### PR TITLE
Fix boolean in array

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -323,9 +323,9 @@ func (this *PdfWriter) writeValue(value *PdfValue) {
 
 	case PDF_TYPE_BOOLEAN:
 		if value.Bool {
-			this.straightOut("true")
+			this.straightOut("true ")
 		} else {
-			this.straightOut("false")
+			this.straightOut("false ")
 		}
 		break
 


### PR DESCRIPTION
Add a space after boolean like there is after every other type to be able to put them in an array.