### PR TITLE
Fix crashes induces by malformed compressed data

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -506,7 +506,10 @@ func (this *PdfReader) resolveCompressedObject(objSpec *PdfValue) (*PdfValue, er
 		// Decompress if filter is /FlateDecode
 		// Uncompress zlib compressed data
 		var out bytes.Buffer
-		zlibReader, _ := zlib.NewReader(bytes.NewBuffer(compressedObj.Stream.Bytes))
+		zlibReader, err := zlib.NewReader(bytes.NewBuffer(compressedObj.Stream.Bytes))
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to uncompress data")
+		}
 		defer zlibReader.Close()
 		io.Copy(&out, zlibReader)
 
@@ -1422,7 +1425,10 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 		case "/FlateDecode":
 			// Uncompress zlib compressed data
 			var out bytes.Buffer
-			zlibReader, _ := zlib.NewReader(bytes.NewBuffer(stream))
+			zlibReader, err := zlib.NewReader(bytes.NewBuffer(stream))
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to uncompress data")
+			}
 			defer zlibReader.Close()
 			io.Copy(&out, zlibReader)
 


### PR DESCRIPTION
`zlib.NewReader` can return `nil` value in case of malformed compressed data (https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/compress/zlib/reader.go;l=82), this would lead to a crash on an attempt to use `zlibReader`. Implemented error handling will eliminate such crashes.