### PR TITLE
Int 986 - Fix infinite loop for PDF initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,10 @@ Generated PDF:
 Screenshot of PDF:
 
 ![example.jpg](https://user-images.githubusercontent.com/9421180/62728726-18b87500-b9e2-11e9-885c-7c68b7ac6222.jpg)
+
+
+------------
+
+# Change log
+- Added ASCII85Decode to support importing / decoding of Fedex international labels that was not supported by this library
+

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/phpdave11/gofpdi
+module github.com/happyreturns/gofpdi
 
-go 1.12
+go 1.16
 
-require github.com/pkg/errors v0.8.1
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/importer.go
+++ b/importer.go
@@ -130,16 +130,16 @@ func (this *Importer) GetPageSizes() map[int]map[string]map[string]float64 {
 	return result
 }
 
-func (this *Importer) ImportPage(pageno int, box string) int {
+func (this *Importer) ImportPage(pageno int, box string) (int, error) {
 	// If page has already been imported, return existing tplN
 	pageNameNumber := fmt.Sprintf("%s-%04d", this.sourceFile, pageno)
 	if _, ok := this.importedPages[pageNameNumber]; ok {
-		return this.importedPages[pageNameNumber]
+		return this.importedPages[pageNameNumber], nil
 	}
 
 	res, err := this.GetWriter().ImportPage(this.GetReader(), pageno, box)
 	if err != nil {
-		panic(err)
+		return 0, fmt.Errorf("importer import page: %s", err)
 	}
 
 	// Get current template id
@@ -154,7 +154,7 @@ func (this *Importer) ImportPage(pageno int, box string) int {
 	// Cache imported page tplN
 	this.importedPages[pageNameNumber] = tplN
 
-	return tplN
+	return tplN, nil
 }
 
 func (this *Importer) SetNextObjectID(objId int) {

--- a/reader.go
+++ b/reader.go
@@ -4,14 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
+	"encoding/ascii85"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type PdfReader struct {
@@ -1423,13 +1425,23 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 			// Uncompress zlib compressed data
 			var out bytes.Buffer
 			zlibReader, _ := zlib.NewReader(bytes.NewBuffer(stream))
+
 			defer zlibReader.Close()
 			io.Copy(&out, zlibReader)
 
 			// Set stream to uncompressed data
 			stream = out.Bytes()
+		case "/ASCII85Decode":
+			encoded := stream
+			// the -3 strips the end of data marker
+			decodedBytes, err := ioutil.ReadAll(ascii85.NewDecoder(bytes.NewBuffer(encoded[:len(encoded)-3])))
+			if err != nil {
+				return nil, err
+			}
+			stream = decodedBytes
+
 		default:
-			return nil, errors.New("Unspported filter: " + filters[i].Token)
+			return nil, errors.New("Unsupported filter: " + filters[i].Token)
 		}
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -7,9 +7,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 type PdfWriter struct {


### PR DESCRIPTION
The current init() function reads the last 1500 bytes of the input stream and tries to find the 'startxref' token, but it can run into an infinite loop if the EOF is reached before the token is found. This fix breaks out of the loop in that scenario.