### PR TITLE
fix: setting sourceFile on the reader when importing streams

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -90,7 +90,7 @@ func (this *Importer) SetSourceStream(rs *io.ReadSeeker) {
 	this.sourceFile = fmt.Sprintf("%v", rs)
 
 	if _, ok := this.readers[this.sourceFile]; !ok {
-		reader, err := NewPdfReaderFromStream(*rs)
+		reader, err := NewPdfReaderFromStream(this.sourceFile, *rs)
 		if err != nil {
 			panic(err)
 		}

--- a/reader.go
+++ b/reader.go
@@ -6,12 +6,13 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type PdfReader struct {
@@ -31,12 +32,12 @@ type PdfReader struct {
 	pageCount      int
 }
 
-func NewPdfReaderFromStream(rs io.ReadSeeker) (*PdfReader, error) {
+func NewPdfReaderFromStream(sourceFile string, rs io.ReadSeeker) (*PdfReader, error) {
 	length, err := rs.Seek(0, 2)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to determine stream length")
 	}
-	parser := &PdfReader{f: rs, nBytes: length}
+	parser := &PdfReader{f: rs, sourceFile: sourceFile, nBytes: length}
 	if err := parser.init(); err != nil {
 		return nil, errors.Wrap(err, "Failed to initialize parser")
 	}


### PR DESCRIPTION
fixes a bug where it wasn't possible to import from more than one stream at a time. As described in https://github.com/phpdave11/gofpdi/issues/59