### PR TITLE
Bugfix/broken stream merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/phpdave11/gofpdi
+module github.com/cadanapay/gofpdi
 
-go 1.12
+go 1.19
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/chaintraced/gofpdi v1.2.0
+	github.com/pkg/errors v0.9.1
+)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/cadanapay/gofpdi
 
 go 1.19
 
-require (
-	github.com/chaintraced/gofpdi v1.2.0
-	github.com/pkg/errors v0.9.1
-)
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/chaintraced/gofpdi v1.2.0 h1:w/a7pPO21CVS7kvLTyy95jO2LbsqZPh65p1wvmG3wvU=
+github.com/chaintraced/gofpdi v1.2.0/go.mod h1:gSIferGHLGqFq5F2obsgO4S3NlEA5pbYTpqbWdHd9f4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,2 @@
-github.com/chaintraced/gofpdi v1.2.0 h1:w/a7pPO21CVS7kvLTyy95jO2LbsqZPh65p1wvmG3wvU=
-github.com/chaintraced/gofpdi v1.2.0/go.mod h1:gSIferGHLGqFq5F2obsgO4S3NlEA5pbYTpqbWdHd9f4=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/importer.go
+++ b/importer.go
@@ -90,7 +90,7 @@ func (this *Importer) SetSourceStream(rs *io.ReadSeeker) {
 	this.sourceFile = fmt.Sprintf("%v", rs)
 
 	if _, ok := this.readers[this.sourceFile]; !ok {
-		reader, err := NewPdfReaderFromStream(*rs)
+		reader, err := NewPdfReaderFromStream(this.sourceFile, *rs)
 		if err != nil {
 			panic(err)
 		}

--- a/interface/gofpdi.go
+++ b/interface/gofpdi.go
@@ -1,0 +1,144 @@
+/*
+Package gofpdi wraps the gofpdi PDF library to import existing PDFs as templates. See github.com/phpdave11/gofpdi
+for further information and examples.
+
+Users should call NewImporter() to obtain their own Importer instance to work with.
+To retain backwards compatibility, the package offers a default Importer that may be used via global functions. Note
+however that use of the default Importer is not thread safe.
+*/
+package gofpdimport
+
+import (
+	"io"
+
+	realgofpdi "github.com/cadanapay/gofpdi"
+)
+
+// gofpdiPdf is a partial interface that only implements the functions we need
+// from the PDF generator to put the imported PDF templates on the PDF.
+type gofpdiPdf interface {
+	ImportObjects(objs map[string][]byte)
+	ImportObjPos(objs map[string]map[int]string)
+	ImportTemplates(tpls map[string]string)
+	UseImportedTemplate(tplName string, x float64, y float64, w float64, h float64)
+	SetError(err error)
+}
+
+// Importer wraps an Importer from the gofpdi library.
+type Importer struct {
+	fpdi *realgofpdi.Importer
+}
+
+// NewImporter creates a new Importer wrapping functionality from the gofpdi library.
+func NewImporter() *Importer {
+	return &Importer{
+		fpdi: realgofpdi.NewImporter(),
+	}
+}
+
+// ImportPage imports a page of a PDF file with the specified box (/MediaBox,
+// /TrimBox, /ArtBox, /CropBox, or /BleedBox). Returns a template id that can
+// be used with UseImportedTemplate to draw the template onto the page.
+func (i *Importer) ImportPage(f gofpdiPdf, sourceFile string, pageno int, box string) int {
+	// Set source file for fpdi
+	i.fpdi.SetSourceFile(sourceFile)
+	// return template id
+	return i.getTemplateID(f, pageno, box)
+}
+
+// ImportPageFromStream imports a page of a PDF with the specified box
+// (/MediaBox, TrimBox, /ArtBox, /CropBox, or /BleedBox). Returns a template id
+// that can be used with UseImportedTemplate to draw the template onto the
+// page.
+func (i *Importer) ImportPageFromStream(f gofpdiPdf, rs *io.ReadSeeker, pageno int, box string) int {
+	// Set source stream for fpdi
+	i.fpdi.SetSourceStream(rs)
+	// return template id
+	return i.getTemplateID(f, pageno, box)
+}
+
+func (i *Importer) getTemplateID(f gofpdiPdf, pageno int, box string) int {
+	// Import page
+	tpl := i.fpdi.ImportPage(pageno, box)
+
+	// Import objects into current pdf document
+	// Unordered means that the objects will be returned with a sha1 hash instead of an integer
+	// The objects themselves may have references to other hashes which will be replaced in ImportObjects()
+	tplObjIDs := i.fpdi.PutFormXobjectsUnordered()
+
+	// Set template names and ids (hashes) in gofpdf
+	f.ImportTemplates(tplObjIDs)
+
+	// Get a map[string]string of the imported objects.
+	// The map keys will be the ID of each object.
+	imported := i.fpdi.GetImportedObjectsUnordered()
+
+	// Import gofpdi objects into gofpdf
+	f.ImportObjects(imported)
+
+	// Get a map[string]map[int]string of the object hashes and their positions within each object,
+	// to be replaced with object ids (integers).
+	importedObjPos := i.fpdi.GetImportedObjHashPos()
+
+	// Import gofpdi object hashes and their positions into gopdf
+	f.ImportObjPos(importedObjPos)
+
+	return tpl
+}
+
+// UseImportedTemplate draws the template onto the page at x,y. If w is 0, the
+// template will be scaled to fit based on h. If h is 0, the template will be
+// scaled to fit based on w.
+func (i *Importer) UseImportedTemplate(f gofpdiPdf, tplid int, x float64, y float64, w float64, h float64) {
+	// Get values from fpdi
+	tplName, scaleX, scaleY, tX, tY := i.fpdi.UseTemplate(tplid, x, y, w, h)
+
+	f.UseImportedTemplate(tplName, scaleX, scaleY, tX, tY)
+}
+
+// GetPageSizes returns page dimensions for all pages of the imported pdf.
+// Result consists of map[<page number>]map[<box>]map[<dimension>]<value>.
+// <page number>: page number, note that page numbers start at 1
+// <box>: box identifier, e.g. "/MediaBox"
+// <dimension>: dimension string, either "w" or "h"
+func (i *Importer) GetPageSizes() map[int]map[string]map[string]float64 {
+	return i.fpdi.GetPageSizes()
+}
+
+// Default Importer used by global functions
+var fpdi = NewImporter()
+
+// ImportPage imports a page of a PDF file with the specified box (/MediaBox,
+// /TrimBox, /ArtBox, /CropBox, or /BleedBox). Returns a template id that can
+// be used with UseImportedTemplate to draw the template onto the page.
+// Note: This uses the default Importer. Call NewImporter() to obtain a custom Importer.
+func ImportPage(f gofpdiPdf, sourceFile string, pageno int, box string) int {
+	return fpdi.ImportPage(f, sourceFile, pageno, box)
+}
+
+// ImportPageFromStream imports a page of a PDF with the specified box
+// (/MediaBox, TrimBox, /ArtBox, /CropBox, or /BleedBox). Returns a template id
+// that can be used with UseImportedTemplate to draw the template onto the
+// page.
+// Note: This uses the default Importer. Call NewImporter() to obtain a custom Importer.
+func ImportPageFromStream(f gofpdiPdf, rs *io.ReadSeeker, pageno int, box string) int {
+	return fpdi.ImportPageFromStream(f, rs, pageno, box)
+}
+
+// UseImportedTemplate draws the template onto the page at x,y. If w is 0, the
+// template will be scaled to fit based on h. If h is 0, the template will be
+// scaled to fit based on w.
+// Note: This uses the default Importer. Call NewImporter() to obtain a custom Importer.
+func UseImportedTemplate(f gofpdiPdf, tplid int, x float64, y float64, w float64, h float64) {
+	fpdi.UseImportedTemplate(f, tplid, x, y, w, h)
+}
+
+// GetPageSizes returns page dimensions for all pages of the imported pdf.
+// Result consists of map[<page number>]map[<box>]map[<dimension>]<value>.
+// <page number>: page number, note that page numbers start at 1
+// <box>: box identifier, e.g. "/MediaBox"
+// <dimension>: dimension string, either "w" or "h"
+// Note: This uses the default Importer. Call NewImporter() to obtain a custom Importer.
+func GetPageSizes() map[int]map[string]map[string]float64 {
+	return fpdi.GetPageSizes()
+}

--- a/reader.go
+++ b/reader.go
@@ -6,12 +6,13 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type PdfReader struct {
@@ -31,12 +32,12 @@ type PdfReader struct {
 	pageCount      int
 }
 
-func NewPdfReaderFromStream(rs io.ReadSeeker) (*PdfReader, error) {
+func NewPdfReaderFromStream(sourceFile string, rs io.ReadSeeker) (*PdfReader, error) {
 	length, err := rs.Seek(0, 2)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to determine stream length")
 	}
-	parser := &PdfReader{f: rs, nBytes: length}
+	parser := &PdfReader{f: rs, sourceFile: sourceFile, nBytes: length}
 	if err := parser.init(); err != nil {
 		return nil, errors.Wrap(err, "Failed to initialize parser")
 	}
@@ -1422,7 +1423,10 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 		case "/FlateDecode":
 			// Uncompress zlib compressed data
 			var out bytes.Buffer
-			zlibReader, _ := zlib.NewReader(bytes.NewBuffer(stream))
+			zlibReader, err := zlib.NewReader(bytes.NewBuffer(stream))
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to create zlib reader")
+			}
 			defer zlibReader.Close()
 			io.Copy(&out, zlibReader)
 


### PR DESCRIPTION
Fix library:

1. Merge PDF using byte stream broken due to missing sourceFile identity causing duplicated pages.