### PR TITLE
Allow multipage PDF to be split

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -14,6 +14,7 @@ type Importer struct {
 	tplN          int
 	writer        *PdfWriter
 	importedPages map[string]int
+	writerCount   int
 }
 
 type TplInfo struct {
@@ -59,6 +60,7 @@ func (this *Importer) init() {
 	this.tplMap = make(map[int]*TplInfo, 0)
 	this.writer, _ = NewPdfWriter("")
 	this.importedPages = make(map[string]int, 0)
+	this.writerCount = 0
 }
 
 func (this *Importer) SetSourceFile(f string) {
@@ -83,6 +85,8 @@ func (this *Importer) SetSourceFile(f string) {
 		// Make the next writer start template numbers at this.tplN
 		writer.SetTplIdOffset(this.tplN)
 		this.writers[this.sourceFile] = writer
+		writer.uid = this.writerCount
+		this.writerCount++
 	}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -33,6 +33,7 @@ type PdfWriter struct {
 	current_obj_id  int
 	tpl_id_offset   int
 	use_hash        bool
+	uid             int
 }
 
 type PdfObjectId struct {
@@ -380,7 +381,7 @@ func (this *PdfWriter) PutFormXobjects(reader *PdfReader) (map[string]*PdfObject
 		pdfObjId := new(PdfObjectId)
 		pdfObjId.id = cN
 		pdfObjId.hash = this.shaOfInt(cN)
-		result[fmt.Sprintf("/GOFPDITPL%d", i+this.tpl_id_offset)] = pdfObjId
+		result[fmt.Sprintf("/GOFPDITPL%d-%d", this.uid, i+this.tpl_id_offset)] = pdfObjId
 
 		this.out("<<" + filter + "/Type /XObject")
 		this.out("/Subtype /Form")
@@ -564,5 +565,5 @@ func (this *PdfWriter) UseTemplate(tplid int, _x float64, _y float64, _w float64
 	tData["ty"] = (0 - _y - _h)
 	tData["lty"] = (0 - _y - _h) - (0-h)*(_h/h)
 
-	return fmt.Sprintf("/GOFPDITPL%d", tplid+this.tpl_id_offset), tData["scaleX"], tData["scaleY"], tData["tx"] * this.k, tData["ty"] * this.k
+	return fmt.Sprintf("/GOFPDITPL%d-%d", this.uid, tplid+this.tpl_id_offset), tData["scaleX"], tData["scaleY"], tData["tx"] * this.k, tData["ty"] * this.k
 }


### PR DESCRIPTION
I found that splitting a multipage PDF during import resulted in the wrong content being imported (see Issue #73). I believe I have implemented a fix for this issue which involves giving the PdfWriter it's own unique id to prevent it from using the same template name as another template.