### PR TITLE
Handle PDFs with high object ids

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -4,20 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"encoding/ascii85"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/pkg/errors"
 )
-
-var adobeASCII85 = regexp.MustCompile(`<~|~>`)
 
 type PdfReader struct {
 	availableBoxes []string
@@ -1440,25 +1436,12 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 
 			// Set stream to uncompressed data
 			stream = out.Bytes()
-		case "/ASCII85Decode":
-			if stream, err = uncompressASCII85(stream); err != nil {
-				return nil, err
-			}
 		default:
 			return nil, errors.New("Unspported filter: " + filters[i].Token)
 		}
 	}
 
 	return stream, nil
-}
-
-func uncompressASCII85(compressed []byte) ([]byte, error) {
-	// compressed stream may contain <~ and ~> which are not standard ASCII85. Remove them before decoding
-	compressed = adobeASCII85.ReplaceAll(compressed, []byte{})
-	var out bytes.Buffer
-	reader := ascii85.NewDecoder(bytes.NewBuffer(compressed))
-	io.Copy(&out, reader)
-	return out.Bytes(), nil
 }
 
 func (this *PdfReader) getNumPages() (int, error) {

--- a/writer.go
+++ b/writer.go
@@ -468,20 +468,8 @@ func (this *PdfWriter) putImportedObjects(reader *PdfReader) error {
 
 	// obj_stack will have new items added to it in the inner loop, so do another loop to check for extras
 	// TODO make the order of this the same every time
-	for {
-		atLeastOne := false
-
-		// FIXME:  How to determine number of objects before this loop?
-		for i := 0; i < 9999; i++ {
-			k := i
-			v := this.obj_stack[i]
-
-			if v == nil {
-				continue
-			}
-
-			atLeastOne = true
-
+	for len(this.obj_stack) > 0 {
+		for k, v := range this.obj_stack {
 			nObj, err = reader.resolveObject(v)
 			if err != nil {
 				return errors.Wrap(err, "Unable to resolve object")
@@ -499,11 +487,7 @@ func (this *PdfWriter) putImportedObjects(reader *PdfReader) error {
 			this.endObj()
 
 			// Remove from stack
-			this.obj_stack[k] = nil
-		}
-
-		if !atLeastOne {
-			break
+			delete(this.obj_stack, k)
 		}
 	}
 


### PR DESCRIPTION
Currently, only PDFs with object ids below 9999 are able to be imported. This fix will allow the importing of PDFs containing objects with any id.