### PR TITLE
Do not discard valid whitespace from start of stream

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -4,20 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"encoding/ascii85"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/pkg/errors"
 )
-
-var adobeASCII85 = regexp.MustCompile(`<~|~>`)
 
 type PdfReader struct {
 	availableBoxes []string
@@ -1440,25 +1436,12 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 
 			// Set stream to uncompressed data
 			stream = out.Bytes()
-		case "/ASCII85Decode":
-			if stream, err = uncompressASCII85(stream); err != nil {
-				return nil, err
-			}
 		default:
 			return nil, errors.New("Unspported filter: " + filters[i].Token)
 		}
 	}
 
 	return stream, nil
-}
-
-func uncompressASCII85(compressed []byte) ([]byte, error) {
-	// compressed stream may contain <~ and ~> which are not standard ASCII85. Remove them before decoding
-	compressed = adobeASCII85.ReplaceAll(compressed, []byte{})
-	var out bytes.Buffer
-	reader := ascii85.NewDecoder(bytes.NewBuffer(compressed))
-	io.Copy(&out, reader)
-	return out.Bytes(), nil
 }
 
 func (this *PdfReader) getNumPages() (int, error) {

--- a/reader.go
+++ b/reader.go
@@ -151,6 +151,24 @@ func (this *PdfReader) skipWhitespace(r *bufio.Reader) error {
 	return nil
 }
 
+// Advance reader so that whitespace within a stream is ignored
+func (this *PdfReader) skipStreamWhitespace(r *bufio.Reader) error {
+	b, err := r.ReadByte()
+	if err != nil {
+		return errors.Wrap(err, "Failed to read byte")
+	}
+	if b == '\r' {
+		b2, err := r.ReadByte()
+		if err == nil && b2 != '\n' {
+			r.UnreadByte()
+		}
+	} else if b != '\n' {
+		// No EOL where expected; put it back or handle as error
+		r.UnreadByte()
+	}
+	return nil
+}
+
 // Read a token
 func (this *PdfReader) readToken(r *bufio.Reader) (string, error) {
 	var err error
@@ -669,7 +687,7 @@ func (this *PdfReader) resolveObject(objSpec *PdfValue) (*PdfValue, error) {
 		if token == "stream" {
 			result.Type = PDF_TYPE_STREAM
 
-			err = this.skipWhitespace(r)
+			err = this.skipStreamWhitespace(r)
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to skip whitespace")
 			}
@@ -940,7 +958,7 @@ func (this *PdfReader) readXref() error {
 						return errors.New("Expected next token to be: stream, got: " + t)
 					}
 
-					err = this.skipWhitespace(r)
+					err = this.skipStreamWhitespace(r)
 					if err != nil {
 						return errors.Wrap(err, "Failed to skip whitespace")
 					}


### PR DESCRIPTION
The only whitespace that should be skipped in a stream is a single '\n' or a '\r' followed by an optional '\n'. All other whitespace must be included in the stream.