### PR TITLE
Allow page contents to be a reference to an array

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -4,20 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"encoding/ascii85"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/pkg/errors"
 )
-
-var adobeASCII85 = regexp.MustCompile(`<~|~>`)
 
 type PdfReader struct {
 	availableBoxes []string
@@ -1440,25 +1436,12 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 
 			// Set stream to uncompressed data
 			stream = out.Bytes()
-		case "/ASCII85Decode":
-			if stream, err = uncompressASCII85(stream); err != nil {
-				return nil, err
-			}
 		default:
 			return nil, errors.New("Unspported filter: " + filters[i].Token)
 		}
 	}
 
 	return stream, nil
-}
-
-func uncompressASCII85(compressed []byte) ([]byte, error) {
-	// compressed stream may contain <~ and ~> which are not standard ASCII85. Remove them before decoding
-	compressed = adobeASCII85.ReplaceAll(compressed, []byte{})
-	var out bytes.Buffer
-	reader := ascii85.NewDecoder(bytes.NewBuffer(compressed))
-	io.Copy(&out, reader)
-	return out.Bytes(), nil
 }
 
 func (this *PdfReader) getNumPages() (int, error) {

--- a/reader.go
+++ b/reader.go
@@ -1353,8 +1353,13 @@ func (this *PdfReader) getPageContent(objSpec *PdfValue) ([]*PdfValue, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to resolve object")
 		}
-		contents = append(contents, content)
-	} else if objSpec.Type == PDF_TYPE_ARRAY {
+		if content.Value.Type == PDF_TYPE_ARRAY {
+			objSpec = content.Value
+		} else {
+			contents = append(contents, content)
+		}
+	}
+	if objSpec.Type == PDF_TYPE_ARRAY {
 		// If objSpec is an array, loop through the array and recursively get page content and append to contents
 		for i := 0; i < len(objSpec.Array); i++ {
 			tmpContents, err := this.getPageContent(objSpec.Array[i])


### PR DESCRIPTION
It is possible for a page /Contents object to be a reference to an array of references to streams as well as a direct array. The getPageContent function now allows for such a reference. Attached is a PDF that has a /Contents object which is a reference to an array that demonstrates the fix.
[array-ref.pdf](https://github.com/user-attachments/files/27709289/array-ref.pdf)
