### PR TITLE
Select correct box from hierarchy when importing

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -4,20 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"encoding/ascii85"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/pkg/errors"
 )
-
-var adobeASCII85 = regexp.MustCompile(`<~|~>`)
 
 type PdfReader struct {
 	availableBoxes []string
@@ -1440,25 +1436,12 @@ func (this *PdfReader) rebuildContentStream(content *PdfValue) ([]byte, error) {
 
 			// Set stream to uncompressed data
 			stream = out.Bytes()
-		case "/ASCII85Decode":
-			if stream, err = uncompressASCII85(stream); err != nil {
-				return nil, err
-			}
 		default:
 			return nil, errors.New("Unspported filter: " + filters[i].Token)
 		}
 	}
 
 	return stream, nil
-}
-
-func uncompressASCII85(compressed []byte) ([]byte, error) {
-	// compressed stream may contain <~ and ~> which are not standard ASCII85. Remove them before decoding
-	compressed = adobeASCII85.ReplaceAll(compressed, []byte{})
-	var out bytes.Buffer
-	reader := ascii85.NewDecoder(bytes.NewBuffer(compressed))
-	io.Copy(&out, reader)
-	return out.Bytes(), nil
 }
 
 func (this *PdfReader) getNumPages() (int, error) {

--- a/writer.go
+++ b/writer.go
@@ -115,6 +115,22 @@ func (this *PdfWriter) ClearImportedObjects() {
 	this.written_objs = make(map[*PdfObjectId][]byte, 0)
 }
 
+func getValidBoxName(boxes map[string]map[string]float64, name string) string {
+	if bm, ok := boxes[name]; !ok || len(bm) == 0 {
+		switch name {
+		case "/ArtBox":
+			return getValidBoxName(boxes, "/TrimBox")
+		case "/TrimBox":
+			return getValidBoxName(boxes, "/BleedBox")
+		case "/BleedBox":
+			return getValidBoxName(boxes, "/CropBox")
+		case "/CropBox":
+			return "/MediaBox"
+		}
+	}
+	return name
+}
+
 // Create a PdfTemplate object from a page number (e.g. 1) and a boxName (e.g. MediaBox)
 func (this *PdfWriter) ImportPage(reader *PdfReader, pageno int, boxName string) (int, error) {
 	var err error
@@ -129,13 +145,7 @@ func (this *PdfWriter) ImportPage(reader *PdfReader, pageno int, boxName string)
 	}
 
 	// If requested box name does not exist for this page, use an alternate box
-	if _, ok := pageBoxes[boxName]; !ok {
-		if boxName == "/BleedBox" || boxName == "/TrimBox" || boxName == "ArtBox" {
-			boxName = "/CropBox"
-		} else if boxName == "/CropBox" {
-			boxName = "/MediaBox"
-		}
-	}
+	boxName = getValidBoxName(pageBoxes, boxName)
 
 	// If the requested box name or an alternate box name cannot be found, trigger an error
 	// TODO: Improve error handling


### PR DESCRIPTION
If the PDF to be imported does not contain the requested box, back off through the box hierarchy to find the most appropriate one to use instead. Attached is a PDF that has a CropBox but not a TrimBox. Currently, if that PDF is imported using the TrimBox, the alternative box lookup fails and no content is displayed.
[croptest.pdf](https://github.com/user-attachments/files/28341146/croptest.pdf)
